### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BunnyNabbit/chunked-vox/security/code-scanning/1](https://github.com/BunnyNabbit/chunked-vox/security/code-scanning/1)

To fix the problem, add a `permissions` key to the workflow file. This can be done at the root level (applies to all jobs) or at the job level (applies only to the specified job). The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write. Since the workflow uses Coveralls, which typically only requires read access to repository contents and the ability to post status checks (which is covered by `checks: write` if needed), starting with `contents: read` is safe. If additional permissions are required for Coveralls or other steps, they can be added as needed. For now, add the following at the top level of the workflow, just after the `name` field and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
